### PR TITLE
issue 5 take 2

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,7 +12,6 @@ vagrant up
 
 printf "CREATE BASE IMAGE\n"
 vagrant ssh -c "cd /vagrant && sudo --preserve-env=LC_DEFAULT_USER,LC_SSH_AUTH_KEY,LC_PACKER_GITHUB_API_TOKEN ./scripts/create-image.sh"
-dd if=./images/scooby.img of=./images/scooby-agent.img bs=1M status=progress
 
 printf "CREATE SERVER IMAGE\n"
 vagrant ssh -c "cd /vagrant && sudo --preserve-env=LC_EXTERNAL_IP,LC_EXTERNAL_NET,LC_EXTERNAL_GW,LC_EXTERNAL_DOMAIN,LC_PRIMARY_DNS,LC_EXTERNAL_DEVICE,LC_HOSTNAME,LC_INTERNAL_DEVICE,LC_INTERNAL_IP,LC_INTERNAL_NET,LC_INTERNAL_DOMAIN,LC_SECONDARY_DNS ./scripts/configure-image.sh"

--- a/scripts/configure-agent.sh
+++ b/scripts/configure-agent.sh
@@ -1,5 +1,23 @@
 #!/bin/sh
 
+createAgentBase() {
+  #MOUNT IMAGE AS LOOP DEVICE
+  mkdir -p ${BOOT_MNT}
+  mkdir -p ${ROOT_MNT}
+  mount ${LOOP_DEV}p1 ${BOOT_MNT}
+  mount ${LOOP_DEV}p2 ${ROOT_MNT}
+
+  #COPY IMAGE INTO BASE
+  mkdir -p ${ROOT_MNT}${BASE_DIR}/boot
+  BASE_DIR_RELATIVE=$(printf "${BASE_DIR}" | grep -oE "[^\/].*$")
+  rsync -xa --info=progress2 --exclude="${BASE_DIR_RELATIVE}" ${ROOT_MNT}/* ${ROOT_MNT}${BASE_DIR}/
+  rsync -xa --info=progress2 ${BOOT_MNT}/* ${ROOT_MNT}${BASE_DIR}/boot
+
+  #UNMOUNT LOOP DEVICES
+  umount ${BOOT_MNT}
+  umount ${ROOT_MNT}
+}
+
 configureAgent() {
 
 AGENT=${1}
@@ -17,7 +35,6 @@ AGENT_ROOT=${ROOT_MNT}${CONFIG_DIR}/${AGENT}
 printf "CONFIGURING AGENT ${AGENT}\n"
 
 ### AGENT HOST ENTRY
-AGENT_IP=$(cat ${AGENT_ROOT}/ip)
 cat - >> ${ROOT_MNT}/etc/hosts << EOF
 ${AGENT_IP} ${AGENT}
 EOF

--- a/scripts/configure-image.sh
+++ b/scripts/configure-image.sh
@@ -11,7 +11,6 @@ VAGRANT_IMAGE=${VAGRANT}/images/scooby.img
 AGENT_DIR=${VAGRANT}/agents
 
 LOOP_DEV=/dev/loop0
-LOOP_DEV2=/dev/loop1
 BOOT_MNT=/tmp/boot
 ROOT_MNT=/tmp/root
 
@@ -25,9 +24,9 @@ resizeImage
 
 losetup -Pf ${VAGRANT_IMAGE}
 
+createAgentBase
 configureBoot
 configureRoot
-importAgentImage
 configureAgents
 
 losetup -D


### PR DESCRIPTION
so basically instead of saving a pristine copy of the image to use for the agent base after configuring the server
just insert the agent base image into the server image before configuring it
that way we save a ton of time copying files twice